### PR TITLE
Add RemoveWatcher API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ branches:
     - master
 
 before_install:
-  - wget http://apache.claz.org/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz
+  - wget http://apache.claz.org/zookeeper/zookeeper-3.5.2-alpha/zookeeper-3.5.2-alpha.tar.gz
   - tar -zxvf zookeeper*tar.gz
+  - ant -buildfile zookeeper-3.5.2-alpha/build.xml jar compile-test
+  - ant -buildfile zookeeper-3.5.2-alpha/src/contrib/fatjar/build.xml jar
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.6.2
+  - 1.7
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 Native Go Zookeeper Client Library
 ===================================
 
+[![GoDoc](https://godoc.org/github.com/samuel/go-zookeeper?status.svg)](https://godoc.org/github.com/samuel/go-zookeeper)
 [![Build Status](https://travis-ci.org/samuel/go-zookeeper.png)](https://travis-ci.org/samuel/go-zookeeper)
 [![Coverage Status](https://coveralls.io/repos/github/samuel/go-zookeeper/badge.svg?branch=master)](https://coveralls.io/github/samuel/go-zookeeper?branch=master)
-
-Documentation: http://godoc.org/github.com/samuel/go-zookeeper/zk
 
 License
 -------

--- a/zk/cluster_test.go
+++ b/zk/cluster_test.go
@@ -134,6 +134,10 @@ func TestNoQuorum(t *testing.T) {
 	DefaultLogger.Printf("    Kill the leader")
 	disconnectWatcher2 := sl.NewWatcher(sessionStateMatcher(StateDisconnected))
 	tc.StopServer(hasSessionEvent2.Server)
+	tmpEvent := sl.NewWatcher(sessionStateMatcher(StateDisconnected)).Wait(4 * time.Second)
+	if tmpEvent == nil {
+		t.Fatalf("StateDisconnected event not received from server: %s", hasSessionEvent2.Server)
+	}
 
 	disconnectedEvent2 := disconnectWatcher2.Wait(8 * time.Second)
 	if disconnectedEvent2 == nil {

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -44,9 +44,9 @@ const (
 type watchType int
 
 const (
-	watchTypeData  = iota
-	watchTypeExist = iota
-	watchTypeChild = iota
+	watchTypeData = iota
+	watchTypeExist
+	watchTypeChild
 )
 
 type watchPathType struct {
@@ -251,7 +251,7 @@ func (c *Conn) State() State {
 	return State(atomic.LoadInt32((*int32)(&c.state)))
 }
 
-// SessionId returns the current session id of the connection.
+// SessionID returns the current session id of the connection.
 func (c *Conn) SessionID() int64 {
 	return atomic.LoadInt64(&c.sessionID)
 }

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -867,6 +867,7 @@ func (c *Conn) Sync(path string) (string, error) {
 type MultiResponse struct {
 	Stat   *Stat
 	String string
+	Error  error
 }
 
 // Multi executes multiple ZooKeeper operations or none of them. The provided
@@ -897,7 +898,7 @@ func (c *Conn) Multi(ops ...interface{}) ([]MultiResponse, error) {
 	_, err := c.request(opMulti, req, res, nil)
 	mr := make([]MultiResponse, len(res.Ops))
 	for i, op := range res.Ops {
-		mr[i] = MultiResponse{Stat: op.Stat, String: op.String}
+		mr[i] = MultiResponse{Stat: op.Stat, String: op.String, Error: op.Err.toError()}
 	}
 	return mr, err
 }

--- a/zk/conn.go
+++ b/zk/conn.go
@@ -100,6 +100,8 @@ type Conn struct {
 	reconnectDelay time.Duration
 
 	logger Logger
+
+	buf []byte
 }
 
 // connOption represents a connection option.
@@ -195,6 +197,7 @@ func Connect(servers []string, sessionTimeout time.Duration, options ...connOpti
 		watchers:       make(map[watchPathType][]chan Event),
 		passwd:         emptyPassword,
 		logger:         DefaultLogger,
+		buf:            make([]byte, bufferSize),
 
 		// Debug
 		reconnectDelay: 0,
@@ -601,16 +604,14 @@ func (c *Conn) authenticate() error {
 }
 
 func (c *Conn) sendData(req *request) error {
-	buf := make([]byte, bufferSize)
-
 	header := &requestHeader{req.xid, req.opcode}
-	n, err := encodePacket(buf[4:], header)
+	n, err := encodePacket(c.buf[4:], header)
 	if err != nil {
 		req.recvChan <- response{-1, err}
 		return nil
 	}
 
-	n2, err := encodePacket(buf[4+n:], req.pkt)
+	n2, err := encodePacket(c.buf[4+n:], req.pkt)
 	if err != nil {
 		req.recvChan <- response{-1, err}
 		return nil
@@ -618,7 +619,7 @@ func (c *Conn) sendData(req *request) error {
 
 	n += n2
 
-	binary.BigEndian.PutUint32(buf[:4], uint32(n))
+	binary.BigEndian.PutUint32(c.buf[:4], uint32(n))
 
 	c.requestsLock.Lock()
 	select {
@@ -632,7 +633,7 @@ func (c *Conn) sendData(req *request) error {
 	c.requestsLock.Unlock()
 
 	c.conn.SetWriteDeadline(time.Now().Add(c.recvTimeout))
-	_, err = c.conn.Write(buf[:n+4])
+	_, err = c.conn.Write(c.buf[:n+4])
 	c.conn.SetWriteDeadline(time.Time{})
 	if err != nil {
 		req.recvChan <- response{-1, err}
@@ -647,7 +648,6 @@ func (c *Conn) sendLoop() error {
 	pingTicker := time.NewTicker(c.pingInterval)
 	defer pingTicker.Stop()
 
-	buf := make([]byte, bufferSize)
 	for {
 		select {
 		case req := <-c.sendChan:
@@ -655,15 +655,15 @@ func (c *Conn) sendLoop() error {
 				return err
 			}
 		case <-pingTicker.C:
-			n, err := encodePacket(buf[4:], &requestHeader{Xid: -2, Opcode: opPing})
+			n, err := encodePacket(c.buf[4:], &requestHeader{Xid: -2, Opcode: opPing})
 			if err != nil {
 				panic("zk: opPing should never fail to serialize")
 			}
 
-			binary.BigEndian.PutUint32(buf[:4], uint32(n))
+			binary.BigEndian.PutUint32(c.buf[:4], uint32(n))
 
 			c.conn.SetWriteDeadline(time.Now().Add(c.recvTimeout))
-			_, err = c.conn.Write(buf[:n+4])
+			_, err = c.conn.Write(c.buf[:n+4])
 			c.conn.SetWriteDeadline(time.Time{})
 			if err != nil {
 				c.conn.Close()

--- a/zk/constants.go
+++ b/zk/constants.go
@@ -34,13 +34,13 @@ const (
 )
 
 const (
-	EventNodeCreated         = EventType(1)
-	EventNodeDeleted         = EventType(2)
-	EventNodeDataChanged     = EventType(3)
-	EventNodeChildrenChanged = EventType(4)
+	EventNodeCreated         EventType = 1
+	EventNodeDeleted         EventType = 2
+	EventNodeDataChanged     EventType = 3
+	EventNodeChildrenChanged EventType = 4
 
-	EventSession     = EventType(-1)
-	EventNotWatching = EventType(-2)
+	EventSession     EventType = -1
+	EventNotWatching EventType = -2
 )
 
 var (
@@ -55,14 +55,13 @@ var (
 )
 
 const (
-	StateUnknown           = State(-1)
-	StateDisconnected      = State(0)
-	StateConnecting        = State(1)
-	StateAuthFailed        = State(4)
-	StateConnectedReadOnly = State(5)
-	StateSaslAuthenticated = State(6)
-	StateExpired           = State(-112)
-	// StateAuthFailed        = State(-113)
+	StateUnknown           State = -1
+	StateDisconnected      State = 0
+	StateConnecting        State = 1
+	StateAuthFailed        State = 4
+	StateConnectedReadOnly State = 5
+	StateSaslAuthenticated State = 6
+	StateExpired           State = -112
 
 	StateConnected  = State(100)
 	StateHasSession = State(101)
@@ -155,20 +154,20 @@ const (
 	errBadArguments         = -8
 	errInvalidState         = -9
 	// API errors
-	errAPIError                = ErrCode(-100)
-	errNoNode                  = ErrCode(-101) // *
-	errNoAuth                  = ErrCode(-102)
-	errBadVersion              = ErrCode(-103) // *
-	errNoChildrenForEphemerals = ErrCode(-108)
-	errNodeExists              = ErrCode(-110) // *
-	errNotEmpty                = ErrCode(-111)
-	errSessionExpired          = ErrCode(-112)
-	errInvalidCallback         = ErrCode(-113)
-	errInvalidAcl              = ErrCode(-114)
-	errAuthFailed              = ErrCode(-115)
-	errClosing                 = ErrCode(-116)
-	errNothing                 = ErrCode(-117)
-	errSessionMoved            = ErrCode(-118)
+	errAPIError                ErrCode = -100
+	errNoNode                  ErrCode = -101 // *
+	errNoAuth                  ErrCode = -102
+	errBadVersion              ErrCode = -103 // *
+	errNoChildrenForEphemerals ErrCode = -108
+	errNodeExists              ErrCode = -110 // *
+	errNotEmpty                ErrCode = -111
+	errSessionExpired          ErrCode = -112
+	errInvalidCallback         ErrCode = -113
+	errInvalidAcl              ErrCode = -114
+	errAuthFailed              ErrCode = -115
+	errClosing                 ErrCode = -116
+	errNothing                 ErrCode = -117
+	errSessionMoved            ErrCode = -118
 )
 
 // Constants for ACL permissions

--- a/zk/constants.go
+++ b/zk/constants.go
@@ -28,6 +28,7 @@ const (
 	opClose        = -11
 	opSetAuth      = 100
 	opSetWatches   = 101
+	opError        = -1
 	// Not in protocol, used internally
 	opWatcherEvent = -2
 )

--- a/zk/lock.go
+++ b/zk/lock.go
@@ -58,8 +58,16 @@ func (l *Lock) Lock() error {
 			parts := strings.Split(l.path, "/")
 			pth := ""
 			for _, p := range parts[1:] {
+				var exists bool
 				pth += "/" + p
-				_, err := l.c.Create(pth, []byte{}, 0, l.acl)
+				exists, _, err = l.c.Exists(pth)
+				if err != nil {
+					return err
+				}
+				if exists == true {
+					continue
+				}
+				_, err = l.c.Create(pth, []byte{}, 0, l.acl)
 				if err != nil && err != ErrNodeExists {
 					return err
 				}

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -99,41 +99,41 @@ func StartTestCluster(size int, stdout, stderr io.Writer) (*TestCluster, error) 
 	return cluster, nil
 }
 
-func (ts *TestCluster) Connect(idx int) (*Conn, error) {
-	zk, _, err := Connect([]string{fmt.Sprintf("127.0.0.1:%d", ts.Servers[idx].Port)}, time.Second*15)
+func (tc *TestCluster) Connect(idx int) (*Conn, error) {
+	zk, _, err := Connect([]string{fmt.Sprintf("127.0.0.1:%d", tc.Servers[idx].Port)}, time.Second*15)
 	return zk, err
 }
 
-func (ts *TestCluster) ConnectAll() (*Conn, <-chan Event, error) {
-	return ts.ConnectAllTimeout(time.Second * 15)
+func (tc *TestCluster) ConnectAll() (*Conn, <-chan Event, error) {
+	return tc.ConnectAllTimeout(time.Second * 15)
 }
 
-func (ts *TestCluster) ConnectAllTimeout(sessionTimeout time.Duration) (*Conn, <-chan Event, error) {
-	return ts.ConnectWithOptions(sessionTimeout)
+func (tc *TestCluster) ConnectAllTimeout(sessionTimeout time.Duration) (*Conn, <-chan Event, error) {
+	return tc.ConnectWithOptions(sessionTimeout)
 }
 
-func (ts *TestCluster) ConnectWithOptions(sessionTimeout time.Duration, options ...connOption) (*Conn, <-chan Event, error) {
-	hosts := make([]string, len(ts.Servers))
-	for i, srv := range ts.Servers {
+func (tc *TestCluster) ConnectWithOptions(sessionTimeout time.Duration, options ...connOption) (*Conn, <-chan Event, error) {
+	hosts := make([]string, len(tc.Servers))
+	for i, srv := range tc.Servers {
 		hosts[i] = fmt.Sprintf("127.0.0.1:%d", srv.Port)
 	}
 	zk, ch, err := Connect(hosts, sessionTimeout, options...)
 	return zk, ch, err
 }
 
-func (ts *TestCluster) Stop() error {
-	for _, srv := range ts.Servers {
+func (tc *TestCluster) Stop() error {
+	for _, srv := range tc.Servers {
 		srv.Srv.Stop()
 	}
-	defer os.RemoveAll(ts.Path)
-	return ts.waitForStop(5, time.Second)
+	defer os.RemoveAll(tc.Path)
+	return tc.waitForStop(5, time.Second)
 }
 
 // waitForStart blocks until the cluster is up
-func (ts *TestCluster) waitForStart(maxRetry int, interval time.Duration) error {
+func (tc *TestCluster) waitForStart(maxRetry int, interval time.Duration) error {
 	// verify that the servers are up with SRVR
-	serverAddrs := make([]string, len(ts.Servers))
-	for i, s := range ts.Servers {
+	serverAddrs := make([]string, len(tc.Servers))
+	for i, s := range tc.Servers {
 		serverAddrs[i] = fmt.Sprintf("127.0.0.1:%d", s.Port)
 	}
 
@@ -148,10 +148,10 @@ func (ts *TestCluster) waitForStart(maxRetry int, interval time.Duration) error 
 }
 
 // waitForStop blocks until the cluster is down
-func (ts *TestCluster) waitForStop(maxRetry int, interval time.Duration) error {
+func (tc *TestCluster) waitForStop(maxRetry int, interval time.Duration) error {
 	// verify that the servers are up with RUOK
-	serverAddrs := make([]string, len(ts.Servers))
-	for i, s := range ts.Servers {
+	serverAddrs := make([]string, len(tc.Servers))
+	for i, s := range tc.Servers {
 		serverAddrs[i] = fmt.Sprintf("127.0.0.1:%d", s.Port)
 	}
 

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -109,11 +109,15 @@ func (ts *TestCluster) ConnectAll() (*Conn, <-chan Event, error) {
 }
 
 func (ts *TestCluster) ConnectAllTimeout(sessionTimeout time.Duration) (*Conn, <-chan Event, error) {
+	return ts.ConnectWithOptions(sessionTimeout)
+}
+
+func (ts *TestCluster) ConnectWithOptions(sessionTimeout time.Duration, options ...connOption) (*Conn, <-chan Event, error) {
 	hosts := make([]string, len(ts.Servers))
 	for i, srv := range ts.Servers {
 		hosts[i] = fmt.Sprintf("127.0.0.1:%d", srv.Port)
 	}
-	zk, ch, err := Connect(hosts, sessionTimeout)
+	zk, ch, err := Connect(hosts, sessionTimeout, options...)
 	return zk, ch, err
 }
 

--- a/zk/server_help.go
+++ b/zk/server_help.go
@@ -192,3 +192,25 @@ func (tc *TestCluster) StopServer(server string) {
 	}
 	panic(fmt.Sprintf("Unknown server: %s", server))
 }
+
+func (tc *TestCluster) StartAllServers() error {
+	for _, s := range tc.Servers {
+		if err := s.Srv.Start(); err != nil {
+			return fmt.Errorf(
+				"Failed to start server listening on port `%d` : %+v", s.Port, err)
+		}
+	}
+
+	return nil
+}
+
+func (tc *TestCluster) StopAllServers() error {
+	for _, s := range tc.Servers {
+		if err := s.Srv.Stop(); err != nil {
+			return fmt.Errorf(
+				"Failed to stop server listening on port `%d` : %+v", s.Port, err)
+		}
+	}
+
+	return nil
+}

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -125,7 +125,7 @@ func (srv *Server) Start() error {
 			return fmt.Errorf("zk: unable to find server jar")
 		}
 	}
-	srv.cmd = exec.Command("java", "-jar", srv.JarPath, "server", srv.ConfigPath)
+	srv.cmd = exec.Command("java", "-Dzookeeper.admin.enableServer=false", "-jar", srv.JarPath, "server", srv.ConfigPath)
 	srv.cmd.Stdout = srv.Stdout
 	srv.cmd.Stderr = srv.Stderr
 	return srv.cmd.Start()

--- a/zk/server_java.go
+++ b/zk/server_java.go
@@ -86,6 +86,7 @@ func (sc ServerConfig) Marshall(w io.Writer) error {
 var jarSearchPaths = []string{
 	"zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
 	"../zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
+	"../zookeeper-*/build/contrib/fatjar/zookeeper-*-fatjar.jar",
 	"/usr/share/java/zookeeper-*.jar",
 	"/usr/local/zookeeper-*/contrib/fatjar/zookeeper-*-fatjar.jar",
 	"/usr/local/Cellar/zookeeper/*/libexec/contrib/fatjar/zookeeper-*-fatjar.jar",

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -270,6 +270,7 @@ type multiResponseOp struct {
 	Header multiHeader
 	String string
 	Stat   *Stat
+	Err    ErrCode
 }
 type multiResponse struct {
 	Ops        []multiResponseOp
@@ -327,6 +328,8 @@ func (r *multiRequest) Decode(buf []byte) (int, error) {
 }
 
 func (r *multiResponse) Decode(buf []byte) (int, error) {
+	var multiErr error
+
 	r.Ops = make([]multiResponseOp, 0)
 	r.DoneHeader = multiHeader{-1, true, -1}
 	total := 0
@@ -347,6 +350,8 @@ func (r *multiResponse) Decode(buf []byte) (int, error) {
 		switch header.Type {
 		default:
 			return total, ErrAPIError
+		case opError:
+			w = reflect.ValueOf(&res.Err)
 		case opCreate:
 			w = reflect.ValueOf(&res.String)
 		case opSetData:
@@ -362,8 +367,12 @@ func (r *multiResponse) Decode(buf []byte) (int, error) {
 			total += n
 		}
 		r.Ops = append(r.Ops, res)
+		if multiErr == nil && res.Err != errOk {
+			// Use the first error as the error returned from Multi().
+			multiErr = res.Err.toError()
+		}
 	}
-	return total, nil
+	return total, multiErr
 }
 
 type watcherEvent struct {

--- a/zk/structs.go
+++ b/zk/structs.go
@@ -112,6 +112,14 @@ type auth struct {
 	Auth   []byte
 }
 
+type WatcherType int32
+
+const (
+	WatcherTypeChildren = 1
+	WatcherTypeData     = 2
+	WatcherTypeAny      = 3
+)
+
 // Generic request structs
 
 type pathRequest struct {
@@ -251,6 +259,12 @@ type setWatchesRequest struct {
 }
 
 type setWatchesResponse struct{}
+
+type removeWatchesRequest struct {
+	Path string
+	Type WatcherType
+}
+type removeWatchesResponse struct{}
 
 type syncRequest pathRequest
 type syncResponse pathResponse
@@ -596,6 +610,8 @@ func requestStructForOp(op int32) interface{} {
 		return &SetDataRequest{}
 	case opSetWatches:
 		return &setWatchesRequest{}
+	case opRemoveWatches:
+		return &removeWatchesRequest{}
 	case opSync:
 		return &syncRequest{}
 	case opSetAuth:

--- a/zk/structs_test.go
+++ b/zk/structs_test.go
@@ -54,8 +54,7 @@ func encodeDecodeTest(t *testing.T, r interface{}) {
 
 func TestEncodeShortBuffer(t *testing.T) {
 	t.Parallel()
-	buf := make([]byte, 0)
-	_, err := encodePacket(buf, &requestHeader{1, 2})
+	_, err := encodePacket([]byte{}, &requestHeader{1, 2})
 	if err != ErrShortBuffer {
 		t.Errorf("encodePacket should return ErrShortBuffer on a short buffer instead of '%+v'", err)
 		return
@@ -64,8 +63,7 @@ func TestEncodeShortBuffer(t *testing.T) {
 
 func TestDecodeShortBuffer(t *testing.T) {
 	t.Parallel()
-	buf := make([]byte, 0)
-	_, err := decodePacket(buf, &responseHeader{})
+	_, err := decodePacket([]byte{}, &responseHeader{})
 	if err != ErrShortBuffer {
 		t.Errorf("decodePacket should return ErrShortBuffer on a short buffer instead of '%+v'", err)
 		return

--- a/zk/structs_test.go
+++ b/zk/structs_test.go
@@ -16,6 +16,7 @@ func TestEncodeDecodePacket(t *testing.T) {
 	encodeDecodeTest(t, &pathWatchRequest{"path", false})
 	encodeDecodeTest(t, &CheckVersionRequest{"/", -1})
 	encodeDecodeTest(t, &multiRequest{Ops: []multiRequestOp{{multiHeader{opCheck, false, -1}, &CheckVersionRequest{"/", -1}}}})
+	encodeDecodeTest(t, &removeWatchesRequest{"/", WatcherTypeAny})
 }
 
 func TestRequestStructForOp(t *testing.T) {

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -53,7 +53,6 @@ func TestStateChanges(t *testing.T) {
 	verifyEventOrder(eventChan, states, "event channel")
 
 	zk.Close()
-
 	verifyEventOrder(callbackChan, []State{StateDisconnected}, "callback")
 	verifyEventOrder(eventChan, []State{StateDisconnected}, "event channel")
 }

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -134,6 +134,7 @@ func TestIfAuthdataSurvivesReconnect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer ts.Stop()
 
 	zk, _, err := ts.ConnectAll()
 	if err != nil {

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -452,6 +452,479 @@ func TestChildWatch(t *testing.T) {
 	}
 }
 
+//
+// Helpers to make the TestRemoveXXX tests more readable
+//
+
+// create a client connection
+func createZk(t *testing.T, ts *TestCluster) (*Conn, <-chan Event, error) {
+	zk, ch, err := ts.ConnectAll()
+	if err != nil && err != ErrNodeExists {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	return zk, ch, nil
+}
+
+// create an ephemeral node
+func createNode(t *testing.T, zk *Conn, path string) error {
+	_, err := zk.Create(path, []byte{}, FlagEphemeral, WorldACL(PermAll))
+	if err != nil {
+		t.Fatalf("Create returned error: %+v", err)
+	}
+	return nil
+}
+
+// delete the node and assert that there is no error
+func deleteNode(t *testing.T, zk *Conn, path string) error {
+	err := zk.Delete(path, 0)
+	if err != nil && err != ErrNoNode {
+		t.Fatalf("Delete returned error: %+v", err)
+	}
+	return nil
+}
+
+// query the number of watchers for the given watchType
+func getNumWatches(t *testing.T, zk *Conn, watchType watchType) int {
+	count := 0
+	for wpt := range zk.watchers {
+		if wpt.wType == watchType {
+			watchers := zk.watchers[wpt]
+			count += len(watchers)
+		}
+	}
+	return count
+}
+
+// Verifies removing watchers
+func TestRemoveSingleWatcher(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+	createNode(t, zk1, "/node2")
+
+	if _, _, _, err = zk2.ExistsW("/node1"); err != nil {
+		t.Fatalf("ExistsW returned error: %+v", err)
+	}
+	if _, _, _, err = zk2.ExistsW("/node2"); err != nil {
+		t.Fatalf("ExistsW returned error: %+v", err)
+	}
+
+	err = zk2.RemoveWatcher("/node1", WatcherTypeData, false)
+	if err != nil {
+		t.Fatalf("RemoveWatcher returned error: %+v", err)
+	}
+	if n := getNumWatches(t, zk2, watchTypeData); n != 1 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+
+	err = zk2.RemoveWatcher("/node2", WatcherTypeData, false)
+	if err != nil {
+		t.Fatalf("RemoveWatcher returned error: %+v", err)
+	}
+	if n := getNumWatches(t, zk2, watchTypeData); n != 0 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+	deleteNode(t, zk1, "/node2")
+}
+
+// Verifies removing watchers generates corresponding events
+// on the original watcher for each watchType.
+func TestRemoveSingleWatcherWithEvents(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	time.Sleep(10 * time.Millisecond)
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	var (
+		ch <-chan Event
+	)
+
+	createNode(t, zk1, "/node1")
+
+	// ExistsW
+	if _, _, ch, err = zk2.ExistsW("/node2"); err != nil {
+		t.Fatalf("ExistsW returned error: %+v", err)
+	}
+	go func() {
+		if err := zk2.RemoveWatcher("/node2", WatcherTypeData, false); err != nil {
+			t.Fatalf("RemoveWatcher returned error: %+v", err)
+		}
+	}()
+	select {
+	case e := <-ch:
+		if e.Type != EventNodeDataWatchRemoved {
+			t.Fatalf("RemoveWatcher sent the wrong event: %+v", e)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("RemoveWatcher did not send event: EventNodeDataWatchRemoved")
+	}
+
+	// GetW
+	if _, _, ch, err = zk2.GetW("/node1"); err != nil {
+		t.Fatalf("GetW returned error: %+v", err)
+	}
+	go func() {
+		if err := zk2.RemoveWatcher("/node1", WatcherTypeData, false); err != nil {
+			t.Fatalf("RemoveWatcher returned error: %+v", err)
+		}
+	}()
+	select {
+	case e := <-ch:
+		if e.Type != EventNodeDataWatchRemoved {
+			t.Fatalf("RemoveWatcher sent the wrong event: %+v", e)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("RemoveWatcher did not send event: EventNodeDataWatchRemoved")
+	}
+
+	// ChildrenW
+	if _, _, ch, err = zk2.ChildrenW("/node1"); err != nil {
+		t.Fatalf("ChildrenW returned error: %+v", err)
+	}
+	go func() {
+		if err := zk2.RemoveWatcher("/node1", WatcherTypeChildren, false); err != nil {
+			t.Fatalf("RemoveWatcher returned error: %+v", err)
+		}
+	}()
+	select {
+	case e := <-ch:
+		if e.Type != EventNodeChildWatchRemoved {
+			t.Fatalf("RemoveWatcher sent the wrong event: %+v", e)
+		}
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("RemoveWatcher did not send event: EventNodeChildWatchRemoved")
+	}
+
+	// GetW and ChildrenW
+	chs := make([]<-chan Event, 2)
+	_, _, chs[0], err = zk2.GetW("/node1")
+	_, _, chs[1], err = zk2.ChildrenW("/node1")
+
+	go func() {
+		zk2.RemoveWatcher("/node1", WatcherTypeAny, false)
+	}()
+
+	go func() {
+		counter := 0
+		for {
+			select {
+			case e := <-chs[0]:
+				if e.Type == EventNodeDataWatchRemoved {
+					counter += 1
+					if counter == 2 {
+						return
+					}
+				}
+			case e := <-chs[1]:
+				if e.Type == EventNodeChildWatchRemoved {
+					counter += 1
+					if counter == 2 {
+						return
+					}
+				}
+			case <-time.After(500 * time.Millisecond):
+				t.Fatalf("RemoveWatcher did not send event: EventNodeChildWatchRemoved, EventNodeDataWatchRemoved")
+			}
+		}
+	}()
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies removing multiple data watchers
+func TestRemoveMultipleDataWatchers(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	// setup 2 watches on the same node
+	zk2.ExistsW("/node1")
+	zk2.ExistsW("/node1")
+	if n := getNumWatches(t, zk2, watchTypeData); n != 2 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+
+	zk2.RemoveWatcher("/node1", WatcherTypeData, false)
+	if n := getNumWatches(t, zk2, watchTypeData); n != 0 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies removing multiple child watchers
+func TestRemoveMultipleChildWatchers(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	// setup 2 watches on the same node
+	zk2.ChildrenW("/node1")
+	zk2.ChildrenW("/node1")
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 2 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+
+	zk2.RemoveWatcher("/node1", WatcherTypeChildren, false)
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 0 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies that removing WatcherType.Any should remove all watch types:
+// Child, Data, and Exist
+func TestRemoveAllWatchers(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	zk2.GetW("/node1")
+	zk2.GetW("/node1")
+	zk2.ExistsW("/node2")
+	zk2.ExistsW("/node2")
+	zk2.ChildrenW("/node1")
+	zk2.ChildrenW("/node1")
+
+	zk2.RemoveWatcher("/node1", WatcherTypeAny, false)
+	zk2.RemoveWatcher("/node2", WatcherTypeAny, false)
+
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 0 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeData); n != 0 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeExist); n != 0 {
+		t.Fatalf("Wrong number of exist watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies that removing WatcherType.Data should not affect
+// Child watchers.
+func TestRemoveAllDataWatchers(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	zk2.GetW("/node1")
+	zk2.GetW("/node1")
+	zk2.ExistsW("/node2")
+	zk2.ExistsW("/node2")
+	zk2.ChildrenW("/node1")
+	zk2.ChildrenW("/node1")
+
+	zk2.RemoveWatcher("/node1", WatcherTypeData, false)
+	zk2.RemoveWatcher("/node2", WatcherTypeData, false)
+
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 2 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeData); n != 0 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeExist); n != 0 {
+		t.Fatalf("Wrong number of exist watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies that removing WatcherType.Children should not affect
+// Data watchers.
+func TestRemoveAllChildWatchers(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	zk2.GetW("/node1")
+	zk2.GetW("/node1")
+	zk2.ExistsW("/node2")
+	zk2.ExistsW("/node2")
+	zk2.ChildrenW("/node1")
+	zk2.ChildrenW("/node1")
+
+	zk2.RemoveWatcher("/node1", WatcherTypeChildren, false)
+	zk2.RemoveWatcher("/node2", WatcherTypeChildren, false)
+
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 0 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeData); n != 2 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeExist); n != 2 {
+		t.Fatalf("Wrong number of exist watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies removing a watcher that does not exist
+func TestRemoveWatcherNoWatcherError(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+
+	zk2.ChildrenW("/node1")
+
+	err = zk1.RemoveWatcher("/node1", WatcherTypeChildren, false)
+	if err == nil {
+		t.Fatalf("RemoveWatcher should return ErrNoWatcher")
+	} else {
+		if err != ErrNoWatcher {
+			t.Fatalf("RemoveWatcher should return ErrNoWatch instead of: %+v", err)
+		}
+	}
+
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 1 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+
+	deleteNode(t, zk1, "/node1")
+}
+
+// Test verifies when no server connection, and local=true, watches should
+// be removed locally.
+func TestRemoveWatcherWhenNoConnection(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	zk1, _, _ := createZk(t, ts)
+	defer zk1.Close()
+	zk2, _, _ := createZk(t, ts)
+	defer zk2.Close()
+
+	// Start test
+	createNode(t, zk1, "/node1")
+	zk2.ChildrenW("/node1")
+	zk2.ExistsW("/node2")
+
+	// simulate server disconnect
+	ts.Stop()
+
+	// local=false
+	if err = zk2.RemoveWatcher("/node1", WatcherTypeChildren, false); err == nil {
+		t.Fatalf("RemoveWatcher should return error")
+	}
+	if err != ErrNoServer {
+		t.Logf("RemoveWatcher returned unexpected error: %+v", err)
+	}
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 1 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+
+	// local=true
+	if err = zk2.RemoveWatcher("/node2", WatcherTypeData, true); err == nil {
+		t.Fatalf("RemoveWatcher should return error")
+	}
+	if err != ErrNoServer {
+		t.Logf("RemoveWatcher returned unexpected error: %+v", err)
+	}
+	if n := getNumWatches(t, zk2, watchTypeChild); n != 1 {
+		t.Fatalf("Wrong number of child watchers: %d", n)
+	}
+	if n := getNumWatches(t, zk2, watchTypeExist); n != 0 {
+		t.Fatalf("Wrong number of data watchers: %d", n)
+	}
+
+	ts, err = StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+	zk1, _, _ = createZk(t, ts)
+	defer zk1.Close()
+
+	deleteNode(t, zk1, "/node1")
+}
+
 func TestSetWatchers(t *testing.T) {
 	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -11,6 +11,53 @@ import (
 	"time"
 )
 
+func TestStateChanges(t *testing.T) {
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+
+	callbackChan := make(chan Event)
+	f := func(event Event) {
+		callbackChan <- event
+	}
+
+	zk, eventChan, err := ts.ConnectWithOptions(15*time.Second, WithEventCallback(f))
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+
+	verifyEventOrder := func(c <-chan Event, expectedStates []State, source string) {
+		for _, state := range expectedStates {
+			for {
+				event, ok := <-c
+				if !ok {
+					t.Fatalf("unexpected channel close for %s", source)
+				}
+
+				if event.Type != EventSession {
+					continue
+				}
+
+				if event.State != state {
+					t.Fatalf("mismatched state order from %s, expected %v, received %v", source, state, event.State)
+				}
+				break
+			}
+		}
+	}
+
+	states := []State{StateConnecting, StateConnected, StateHasSession}
+	verifyEventOrder(callbackChan, states, "callback")
+	verifyEventOrder(eventChan, states, "event channel")
+
+	zk.Close()
+
+	verifyEventOrder(callbackChan, []State{StateDisconnected}, "callback")
+	verifyEventOrder(eventChan, []State{StateDisconnected}, "event channel")
+}
+
 func TestCreate(t *testing.T) {
 	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {

--- a/zk/zk_test.go
+++ b/zk/zk_test.go
@@ -79,6 +79,54 @@ func TestMulti(t *testing.T) {
 	}
 }
 
+func TestMultiFailures(t *testing.T) {
+	// This test case ensures that we return the errors associated with each
+	// opeThis in the event a call to Multi() fails.
+	const firstPath = "/gozk-test-first"
+	const secondPath = "/gozk-test-second"
+
+	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Stop()
+	zk, _, err := ts.ConnectAll()
+	if err != nil {
+		t.Fatalf("Connect returned error: %+v", err)
+	}
+	defer zk.Close()
+
+	// Ensure firstPath doesn't exist and secondPath does. This will cause the
+	// 2nd operation in the Multi() to fail.
+	if err := zk.Delete(firstPath, -1); err != nil && err != ErrNoNode {
+		t.Fatalf("Delete returned error: %+v", err)
+	}
+	if _, err := zk.Create(secondPath, nil /* data */, 0, WorldACL(PermAll)); err != nil {
+		t.Fatalf("Create returned error: %+v", err)
+	}
+
+	ops := []interface{}{
+		&CreateRequest{Path: firstPath, Data: []byte{1, 2}, Acl: WorldACL(PermAll)},
+		&CreateRequest{Path: secondPath, Data: []byte{3, 4}, Acl: WorldACL(PermAll)},
+	}
+	res, err := zk.Multi(ops...)
+	if err != ErrNodeExists {
+		t.Fatalf("Multi() didn't return correct error: %+v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("Expected 2 responses received %d", len(res))
+	}
+	if res[0].Error != nil {
+		t.Fatalf("First operation returned an unexpected error %+v", res[0].Error)
+	}
+	if res[1].Error != ErrNodeExists {
+		t.Fatalf("Second operation returned incorrect error %+v", res[1].Error)
+	}
+	if _, _, err := zk.Get(firstPath); err != ErrNoNode {
+		t.Fatalf("Node %s was incorrectly created: %+v", firstPath, err)
+	}
+}
+
 func TestGetSetACL(t *testing.T) {
 	ts, err := StartTestCluster(1, nil, logWriter{t: t, p: "[ZKERR] "})
 	if err != nil {


### PR DESCRIPTION
In order to use this API, ZooKeeper 3.5.x or later is required.

NOTE:
- This PR adds a new API to the `Conn` struct: `RemoveWatcher`. Existing client code do not have to change since the other API contract is unchanged. But client application can use the new API as needed.
- If cilent appliction attempt to use the API and have ZooKeeper server < 3.5.x deployed, `ErrUnimplemented` error will be returned. 

Why is this needed ?
- If your application is a long running daemon
- Setups large number of watches which are never triggered
- And there is need to remove these set watches and ensure there is no resource leakage
